### PR TITLE
use callback to return the invitation directly to the listening addre…

### DIFF
--- a/formnet/src/main.rs
+++ b/formnet/src/main.rs
@@ -144,7 +144,10 @@ async fn handle_message(
                     &peer_type.into(),
                     peer_id,
                 ).await {
-                    return server_respond_with_peer_invitation(invitation).await;
+                    return server_respond_with_peer_invitation(
+                        invitation,
+                        *callback
+                    ).await;
                 }
             }
 
@@ -167,7 +170,13 @@ async fn handle_message(
             ).await {
                 println!("Creating peer...");
                 let peer: Peer = api.http_form("POST", "/admin/peers", content)?;
-                respond_with_peer_invitation(&peer, server.clone(), &cidr_tree, keypair).await?;
+                respond_with_peer_invitation(
+                    &peer,
+                    server.clone(), 
+                    &cidr_tree, 
+                    keypair, 
+                    *callback
+                ).await?;
             }
         },
         DisablePeer => {},


### PR DESCRIPTION
…ss, instead of writing it back to the message broker and having to require significant additional data in order for the vmm service to make sense of it